### PR TITLE
fix: Update GitHub publish workflow to resolve Poetry dependency issue

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,9 +11,25 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Publish PyPi package
-        uses: code-specialist/pypi-poetry-publish@v1
+      - uses: actions/checkout@v3
         with:
-          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PUBLISH_REGISTRY_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-          BRANCH: main
+          fetch-depth: 0
+      
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install six  # Install the missing dependency
+          pip install poetry poetry-dynamic-versioning
+      
+      - name: Build and publish
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          poetry config pypi-token.pypi $PYPI_TOKEN
+          poetry build
+          poetry publish


### PR DESCRIPTION
This commit addresses the 'No module named six.moves' error encountered during package publishing:

- Replace third-party code-specialist/pypi-poetry-publish action with direct Poetry commands
- Add explicit installation of the 'six' package which was missing in the GitHub Actions environment
- Set up Python 3.9 environment compatible with project requirements
- Install poetry and poetry-dynamic-versioning dependencies directly
- Configure explicit build and publish steps using Poetry commands

These changes ensure the GitHub workflow can successfully build and publish the package to PyPI when a new release is created, without encountering dependency errors.